### PR TITLE
Reduce memory usage by skipping the LFS files download on checkout

### DIFF
--- a/2_job-download-models/download_models.sh
+++ b/2_job-download-models/download_models.sh
@@ -26,13 +26,13 @@ cd models
 # Downloading model for generating vector embeddings
 GIT_LFS_SKIP_SMUDGE=1 git clone ${EMBEDDING_MODEL_REPO} --branch main embedding-model 
 cd embedding-model
-git checkout ${EMBDEDDING_MODEL_COMMIT}
+GIT_LFS_SKIP_SMUDGE=1 git checkout ${EMBDEDDING_MODEL_COMMIT}
 download_lfs_files $EMBDEDDING_MODEL_COMMIT
 cd ..
   
 # Downloading LLM model that has been fine tuned to handle instructions/q&a
 GIT_LFS_SKIP_SMUDGE=1 git clone ${LLM_MODEL_REPO} --branch main llm-model
 cd llm-model
-git checkout ${LLM_MODEL_COMMIT}
+GIT_LFS_SKIP_SMUDGE=1 git checkout ${LLM_MODEL_COMMIT}
 download_lfs_files $LLM_MODEL_COMMIT
 cd ..


### PR DESCRIPTION
## Problem
**Download Models** task in the AMP was sometimes getting failed with the exit status as 137 (Out of Memory).

## Changes Made
added `GIT_LFS_SKIP_SMUDGE=1` env var for the git checkout process. This prevents Git from attempting to automatically download LFS files into memory during checkout, a step that is unnecessary since the LFS files are being explicitly downloaded through the download_lfs_files function.

## Testing
**PRE:**
<img width="1717" alt="Screenshot 2024-04-08 at 9 07 18 PM 1" src="https://github.com/cloudera/CML_AMP_LLM_Chatbot_Augmented_with_Enterprise_Data/assets/19422305/13b40609-fc7a-421d-b202-9664e07d74bc">

**POST:**
<img width="1719" alt="Screenshot 2024-04-08 at 9 11 52 PM" src="https://github.com/cloudera/CML_AMP_LLM_Chatbot_Augmented_with_Enterprise_Data/assets/19422305/49b96dbd-12df-490b-9c1e-96c65a8703d0">



