### PR TITLE
Pin marshmallow version to 3.26.1

### DIFF
--- a/1_session-install-deps/requirements.txt
+++ b/1_session-install-deps/requirements.txt
@@ -6,3 +6,5 @@ gradio_client==1.3.0
 transformers==4.31.0
 torch==2.0.1
 accelerate==0.21.0
+marshmallow==3.26.1
+


### PR DESCRIPTION
AMP's  task is getting failed
```
  - type: run_job
    entity_label: vectordb_insert
    short_summary: Populate Vector DB with documents embeddings
```

due to marshmallow 4.0.0, a dependency of pymilvus, has deprecated the __version_info__ attribute, so we need to pin to 3.26.1

<img width="729" alt="Screenshot 2025-06-04 at 6 54 07 PM" src="https://github.com/user-attachments/assets/ffd13080-fd05-44ba-974b-4b4fc46bca47" />

**Testing** - Verified by deploying the AMP; all associated tasks completed successfully.