### PR TITLE
Update AMP runtime kernel to Python 3.10

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -9,7 +9,7 @@ date: "2023-04-22"
 
 runtimes:
   - editor: PBJ Workbench
-    kernel: Python 3.9
+    kernel: Python 3.10
     edition: Nvidia GPU
 
 tasks:


### PR DESCRIPTION
## Summary
- Update AMP runtime metadata in `.project-metadata.yaml` from `Python 3.9` to `Python 3.10` for `PBJ Workbench` + `Nvidia GPU`
- Align AMP runtime selection with currently available GPU runtime catalog entries in CML workspaces
- Prevent configure-prototype failures where runtime resolution yields empty `engineImageRuntimeId`

## Validation
- Verified metadata change is the only file change
- Verified branch pushed to fork: `vigneshB-cloud/CDPQE-amp-python310-update`



