### PR TITLE
DSE-55563: pin setuptools<82.0.0 to restore pkg_resources on Python 3.12

### DIFF
--- a/1_session-install-deps/requirements.txt
+++ b/1_session-install-deps/requirements.txt
@@ -1,3 +1,4 @@
+setuptools<82.0.0
 pandas==2.2.3
 milvus==2.3.5
 pymilvus==2.3.8


### PR DESCRIPTION
Verified by deploying the AMP with the changes from the PR


<img width="1628" height="425" alt="Screenshot 2026-04-27 at 2 05 36 PM" src="https://github.com/user-attachments/assets/0c271043-d494-4fbb-941d-8bade0930c3d" />
<img width="1420" height="169" alt="Screenshot 2026-04-27 at 2 05 27 PM" src="https://github.com/user-attachments/assets/9323588e-f643-48e8-9062-61b51a5eb5c4" />

